### PR TITLE
make npx MCP launch non-interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you'd rather configure things yourself:
   "mcpServers": {
     "blitz-iphone": {
       "command": "npx",
-      "args": ["@blitzdev/iphone-mcp"]
+      "args": ["-y", "@blitzdev/iphone-mcp"]
     }
   }
 }
@@ -177,7 +177,7 @@ If you'd rather configure things yourself:
   "mcpServers": {
     "blitz-iphone": {
       "command": "npx",
-      "args": ["@blitzdev/iphone-mcp"]
+      "args": ["-y", "@blitzdev/iphone-mcp"]
     }
   }
 }
@@ -188,7 +188,7 @@ If you'd rather configure things yourself:
 ```toml
 [mcp_servers.blitz-iphone]
 command = "npx"
-args = ["@blitzdev/iphone-mcp"]
+args = ["-y", "@blitzdev/iphone-mcp"]
 ```
 
 **OpenCode** — add to `opencode.json` in your project root:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -200,7 +200,7 @@ function writeJsonMcpConfig(configPath: string): boolean {
   const mcpServers = {
     'blitz-iphone': {
       command: 'npx',
-      args: ['@blitzdev/iphone-mcp'],
+      args: ['-y', '@blitzdev/iphone-mcp'],
     },
   }
 
@@ -264,7 +264,7 @@ function writeOpenCodeConfig(configPath: string): string[] {
 }
 
 function writeCodexConfig(configPath: string): string[] {
-  const tomlBlock = `\n[mcp_servers.blitz-iphone]\ncommand = "npx"\nargs = ["@blitzdev/iphone-mcp"]\n`
+  const tomlBlock = `\n[mcp_servers.blitz-iphone]\ncommand = "npx"\nargs = ["-y", "@blitzdev/iphone-mcp"]\n`
 
   try {
     let existing = ''


### PR DESCRIPTION
Fixes #5

## What changed
- add `-y` to generated `npx` MCP launch commands for Claude Code, Cursor, and Codex
- update the manual README configuration examples to match

## Why
Plain `npx @blitzdev/iphone-mcp` can prompt on first install or cache miss.

MCP stdio startup should stay non-interactive, so the generated and documented launch commands should use `npx -y` consistently.

## Impact
Configured MCP launches become non-interactive and more reliable across clients.

## Validation
- `npm run typecheck`
